### PR TITLE
ci: prepare workflows for main branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
 jobs:
   golangci:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 env:
   GOPROXY: "https://proxy.golang.org"
 
@@ -35,3 +37,12 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-success:
+    name: test-success
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify test matrix
+        run: test "${{ needs.test.result }}" = "success"


### PR DESCRIPTION
## Summary
Prepare GitHub Actions for renaming the default branch from `master` to `main`.

## Changes
- Run lint and test workflows for both `master` and `main` during the migration
- Add a stable `test-success` check that summarizes the full test matrix

## Motivation
- Keep CI active throughout the default branch rename and provide a durable required check for the repository ruleset

## Testing
- `go test ./... -race`
- `make lint`
- `actionlint .github/workflows/*.yml`