### PR TITLE
ci: target workflows at main branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,9 @@ name: Go Lint
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
     branches:
-      - master
       - main
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,9 @@ name: Go Test
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
     branches:
-      - master
       - main
 env:
   GOPROXY: "https://proxy.golang.org"


### PR DESCRIPTION
## Summary
Complete the default branch migration by targeting GitHub Actions exclusively at `main`.

## Changes
- Remove the temporary `master` push and pull request triggers
- Keep the stable `test-success` matrix summary check introduced during migration

## Motivation
- Prevent CI from treating an accidentally recreated `master` branch as a supported integration branch

## Testing
- `actionlint .github/workflows/*.yml`